### PR TITLE
feat: adapt to gpu

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -103,7 +103,7 @@ pub trait AirBuilder: Sized {
     fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I);
 
     fn assert_one<I: Into<Self::Expr>>(&mut self, x: I) {
-        self.assert_zero(x.into() - Self::Expr::ONE);
+        self.assert_zero(x.into() - Self::Expr::one());
     }
 
     fn assert_eq<I1: Into<Self::Expr>, I2: Into<Self::Expr>>(&mut self, x: I1, y: I2) {
@@ -113,13 +113,13 @@ pub trait AirBuilder: Sized {
     /// Assert that `x` is a boolean, i.e. either 0 or 1.
     fn assert_bool<I: Into<Self::Expr>>(&mut self, x: I) {
         let x = x.into();
-        self.assert_zero(x.clone() * (x - Self::Expr::ONE));
+        self.assert_zero(x.clone() * (x - Self::Expr::one()));
     }
 
     /// Assert that `x` is ternary, i.e. either 0, 1 or 2.
     fn assert_tern<I: Into<Self::Expr>>(&mut self, x: I) {
         let x = x.into();
-        self.assert_zero(x.clone() * (x.clone() - Self::Expr::ONE) * (x - Self::Expr::TWO));
+        self.assert_zero(x.clone() * (x.clone() - Self::Expr::one()) * (x - Self::Expr::two()));
     }
 }
 

--- a/air/src/utils.rs
+++ b/air/src/utils.rs
@@ -47,7 +47,7 @@ pub fn xor3<FA: FieldAlgebra>(x: FA, y: FA, z: FA) -> FA {
 /// For boolean inputs `(!x) & y = (1 - x)y`
 #[inline(always)]
 pub fn andn<FA: FieldAlgebra>(x: FA, y: FA) -> FA {
-    (FA::ONE - x) * y
+    (FA::one() - x) * y
 }
 
 /// Compute `xor` on a list of boolean field elements.

--- a/air/src/virtual_column.rs
+++ b/air/src/virtual_column.rs
@@ -7,8 +7,8 @@ use p3_field::{Field, FieldAlgebra};
 /// An affine function over columns in a PAIR.
 #[derive(Clone, Debug)]
 pub struct VirtualPairCol<F: Field> {
-    column_weights: Vec<(PairCol, F)>,
-    constant: F,
+    pub column_weights: Vec<(PairCol, F)>,
+    pub constant: F,
 }
 
 /// A column in a PAIR, i.e. either a preprocessed column or a main trace column.

--- a/air/src/virtual_column.rs
+++ b/air/src/virtual_column.rs
@@ -115,7 +115,7 @@ impl<F: Field> VirtualPairCol<F> {
     {
         let mut result = self.constant.into();
         for (column, weight) in self.column_weights.iter() {
-            result = result +  column.get(preprocessed, main).into() * *weight;
+            result = result + column.get(preprocessed, main).into() * *weight;
         }
         result
     }

--- a/air/src/virtual_column.rs
+++ b/air/src/virtual_column.rs
@@ -115,7 +115,11 @@ impl<F: Field> VirtualPairCol<F> {
     {
         let mut result = self.constant.into();
         for (column, weight) in self.column_weights.iter() {
-            result = result + column.get(preprocessed, main).into() * *weight;
+            if *weight != F::ONE {
+                result = result + column.get(preprocessed, main).into() * *weight;
+            } else {
+                result = result + column.get(preprocessed, main).into();
+            }
         }
         result
     }

--- a/air/src/virtual_column.rs
+++ b/air/src/virtual_column.rs
@@ -115,7 +115,7 @@ impl<F: Field> VirtualPairCol<F> {
     {
         let mut result = self.constant.into();
         for (column, weight) in self.column_weights.iter() {
-            result += column.get(preprocessed, main).into() * *weight;
+            result = result +  column.get(preprocessed, main).into() * *weight;
         }
         result
     }

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -85,6 +85,26 @@ pub trait FieldAlgebra:
     /// If the field has characteristic 2 this is equal to ONE.
     const NEG_ONE: Self;
 
+    fn zero() -> Self {
+        Self::ZERO
+    }
+
+    fn one() -> Self {
+        Self::ONE
+    }
+
+    fn two() -> Self {
+        Self::TWO
+    }
+
+    fn neg_one() -> Self {
+        Self::NEG_ONE
+    }
+
+    fn generator() -> Self {
+        Self::from_f(Self::F::GENERATOR)
+    }
+
     /// Interpret a field element as a commutative algebra element.
     ///
     /// Mathematically speaking, this map is a ring homomorphism from the base field
@@ -210,7 +230,7 @@ pub trait FieldAlgebra:
     /// Construct an iterator which returns powers of `self: self^0, self^1, self^2, ...`.
     #[must_use]
     fn powers(&self) -> Powers<Self> {
-        self.shifted_powers(Self::ONE)
+        self.shifted_powers(Self::one())
     }
 
     /// Construct an iterator which returns powers of `self` shifted by `start: start, start*self^1, start*self^2, ...`.
@@ -284,6 +304,11 @@ pub trait Field:
 
     /// A generator of this field's entire multiplicative group.
     const GENERATOR: Self;
+
+    /// A generator of this field's entire multiplicative group.
+    fn generator() -> Self {
+        Self::GENERATOR
+    }
 
     fn is_zero(&self) -> bool {
         *self == Self::ZERO

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -568,7 +568,7 @@ impl<FA: FieldAlgebra> Iterator for Powers<FA> {
 
     fn next(&mut self) -> Option<FA> {
         let result = self.current.clone();
-        self.current *= self.base.clone();
+        self.current = self.current.clone() * self.base.clone();
         Some(result)
     }
 }

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -85,22 +85,27 @@ pub trait FieldAlgebra:
     /// If the field has characteristic 2 this is equal to ONE.
     const NEG_ONE: Self;
 
+    #[inline(always)]
     fn zero() -> Self {
         Self::ZERO
     }
 
+    #[inline(always)]
     fn one() -> Self {
         Self::ONE
     }
 
+    #[inline(always)]
     fn two() -> Self {
         Self::TWO
     }
 
+    #[inline(always)]
     fn neg_one() -> Self {
         Self::NEG_ONE
     }
 
+    #[inline(always)]
     fn generator() -> Self {
         Self::from_f(Self::F::GENERATOR)
     }
@@ -306,6 +311,7 @@ pub trait Field:
     const GENERATOR: Self;
 
     /// A generator of this field's entire multiplicative group.
+    #[inline(always)]
     fn generator() -> Self {
         Self::GENERATOR
     }

--- a/keccak-air/src/air.rs
+++ b/keccak-air/src/air.rs
@@ -157,7 +157,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
             for r in 0..NUM_ROUNDS {
                 let this_round = local.step_flags[r];
                 let this_round_constant = AB::Expr::from_canonical_u8(rc_value_bit(r, i));
-                rc_bit_i += this_round * this_round_constant;
+                rc_bit_i = rc_bit_i + this_round * this_round_constant;
             }
 
             xor::<AB::Expr>(local.a_prime_prime_0_0_bits[i].into(), rc_bit_i)

--- a/keccak-air/src/air.rs
+++ b/keccak-air/src/air.rs
@@ -32,7 +32,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
 
         let first_step = local.step_flags[0];
         let final_step = local.step_flags[NUM_ROUNDS - 1];
-        let not_final_step = AB::Expr::ONE - final_step;
+        let not_final_step = AB::Expr::one() - final_step;
 
         // If this is the first step, the input A must match the preimage.
         for y in 0..5 {
@@ -98,7 +98,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
                     let a_limb = local.a[y][x][limb];
                     let computed_limb = (limb * BITS_PER_LIMB..(limb + 1) * BITS_PER_LIMB)
                         .rev()
-                        .fold(AB::Expr::ZERO, |acc, z| {
+                        .fold(AB::Expr::zero(), |acc, z| {
                             builder.assert_bool(local.a_prime[y][x][z]);
                             acc.double() + get_bit(z)
                         });
@@ -115,7 +115,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
                 let sum: AB::Expr = (0..5).map(|y| local.a_prime[y][x][z].into()).sum();
                 let diff = sum - local.c_prime[x][z];
                 let four = AB::Expr::from_canonical_u8(4);
-                builder.assert_zero(diff.clone() * (diff.clone() - AB::Expr::TWO) * (diff - four));
+                builder.assert_zero(diff.clone() * (diff.clone() - AB::Expr::two()) * (diff - four));
             }
         }
 
@@ -133,7 +133,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
                 for limb in 0..U64_LIMBS {
                     let computed_limb = (limb * BITS_PER_LIMB..(limb + 1) * BITS_PER_LIMB)
                         .rev()
-                        .fold(AB::Expr::ZERO, |acc, z| acc.double() + get_bit(z));
+                        .fold(AB::Expr::zero(), |acc, z| acc.double() + get_bit(z));
                     builder.assert_eq(computed_limb, local.a_prime_prime[y][x][limb]);
                 }
             }
@@ -144,7 +144,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
             let computed_a_prime_prime_0_0_limb = (limb * BITS_PER_LIMB
                 ..(limb + 1) * BITS_PER_LIMB)
                 .rev()
-                .fold(AB::Expr::ZERO, |acc, z| {
+                .fold(AB::Expr::zero(), |acc, z| {
                     builder.assert_bool(local.a_prime_prime_0_0_bits[z]);
                     acc.double() + local.a_prime_prime_0_0_bits[z]
                 });
@@ -153,7 +153,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
         }
 
         let get_xored_bit = |i| {
-            let mut rc_bit_i = AB::Expr::ZERO;
+            let mut rc_bit_i = AB::Expr::zero();
             for r in 0..NUM_ROUNDS {
                 let this_round = local.step_flags[r];
                 let this_round_constant = AB::Expr::from_canonical_u8(rc_value_bit(r, i));
@@ -168,7 +168,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
             let computed_a_prime_prime_prime_0_0_limb = (limb * BITS_PER_LIMB
                 ..(limb + 1) * BITS_PER_LIMB)
                 .rev()
-                .fold(AB::Expr::ZERO, |acc, z| acc.double() + get_xored_bit(z));
+                .fold(AB::Expr::zero(), |acc, z| acc.double() + get_xored_bit(z));
             builder.assert_eq(
                 computed_a_prime_prime_prime_0_0_limb,
                 a_prime_prime_prime_0_0_limb,

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -103,6 +103,14 @@ impl<F: Clone + Send + Sync, W: Clone, M: Matrix<F>, const DIGEST_ELEMS: usize>
         }
     }
 
+    pub fn from_parts(leaves: Vec<M>, digest_layers: Vec<Vec<[W; DIGEST_ELEMS]>>) -> Self {
+        Self {
+            leaves,
+            digest_layers,
+            _phantom: PhantomData,
+        }
+    }
+
     #[must_use]
     pub fn root(&self) -> Hash<F, W, DIGEST_ELEMS>
     where
@@ -113,7 +121,7 @@ impl<F: Clone + Send + Sync, W: Clone, M: Matrix<F>, const DIGEST_ELEMS: usize>
 }
 
 #[instrument(name = "first digest layer", level = "debug", skip_all)]
-fn first_digest_layer<P, PW, H, M, const DIGEST_ELEMS: usize>(
+pub fn first_digest_layer<P, PW, H, M, const DIGEST_ELEMS: usize>(
     h: &H,
     tallest_matrices: Vec<&M>,
 ) -> Vec<[PW::Value; DIGEST_ELEMS]>
@@ -165,7 +173,7 @@ where
 
 /// Compress `n` digests from the previous layer into `n/2` digests, while potentially mixing in
 /// some leaf data, if there are input matrices with (padded) height `n/2`.
-fn compress_and_inject<P, PW, H, C, M, const DIGEST_ELEMS: usize>(
+pub fn compress_and_inject<P, PW, H, C, M, const DIGEST_ELEMS: usize>(
     prev_layer: &[[PW::Value; DIGEST_ELEMS]],
     matrices_to_inject: Vec<&M>,
     h: &H,

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -51,6 +51,10 @@ impl<MP: MontyParameters> MontyField31<MP> {
         }
     }
 
+    pub const fn value(&self) -> u32 {
+        self.value
+    }
+
     /// Produce a u32 in range [0, P) from a field element corresponding to the true value.
     #[inline(always)]
     pub(crate) fn to_u32(elem: &Self) -> u32 {

--- a/poseidon2/src/internal.rs
+++ b/poseidon2/src/internal.rs
@@ -50,8 +50,8 @@ pub fn matmul_internal<F: Field, FA: FieldAlgebra<F = F>, const WIDTH: usize>(
 ) {
     let sum: FA = state.iter().cloned().sum();
     for i in 0..WIDTH {
-        state[i] *= FA::from_f(mat_internal_diag_m_1[i]);
-        state[i] += sum.clone();
+        state[i] = state[i].clone() * FA::from_f(mat_internal_diag_m_1[i]);
+        state[i] = state[i].clone() + sum.clone();
     }
 }
 


### PR DESCRIPTION
Add `zero()` to `AbstractField` because the following methods cannot be implemented as `const fn` or `const ZERO`.
```rust
impl AbstractField for SymbolicExprF {
    type F = F;

    // #[instrument(skip_all, level = "trace", name = "Zero for SymbolicExprF")]
    fn zero() -> Self {
        let output = SymbolicExprF::alloc();
        let mut code = CUDA_P3_EVAL_CODE.lock().unwrap();
        code.push(Instruction32::f_assign_c(output, F::zero()));
        drop(code);
        output
    }
```